### PR TITLE
Add support for custom SSL certificates

### DIFF
--- a/composeApp/src/androidMain/AndroidManifest.xml
+++ b/composeApp/src/androidMain/AndroidManifest.xml
@@ -46,6 +46,7 @@
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:localeConfig="@xml/locales_config"
+        android:networkSecurityConfig="@xml/network_security_config"
         android:supportsRtl="true"
         android:theme="@style/AppTheme"
         android:usesCleartextTraffic="false"

--- a/composeApp/src/androidMain/res/xml/network_security_config.xml
+++ b/composeApp/src/androidMain/res/xml/network_security_config.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+	<base-config>
+		<trust-anchors>
+			<certificates src="system"/>
+			<certificates src="user"/>
+		</trust-anchors>
+	</base-config>
+</network-security-config>


### PR DESCRIPTION
Allows pano-scrobber to work with self-signed certificates when connecting to Maloja instances. For example I run maloja within LAN only and use a self-signed certificate to provide https to all of my LAN services but pano-scrobber rejects my cert as it is not a system one. This should fix it by allowing user certs