### PR TITLE
Improve Audile support

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/arn/scrobble/utils/Stuff.kt
+++ b/composeApp/src/commonMain/kotlin/com/arn/scrobble/utils/Stuff.kt
@@ -119,7 +119,14 @@ object Stuff {
     const val PACKAGE_AUDILE = "com.mrsep.musicrecognizer"
     const val CHANNEL_SHAZAM = "notification_shazam_match_v1" //"auto_shazam_v2"
     const val CHANNEL_SHAZAM2 = "notification_shazam_foreground_match_v2"
-    const val CHANNEL_AUDILE = "com.mrsep.musicrecognizer.result"
+    const val AUDILE_METADATA_KEY_TRACK_TITLE = "com.mrsep.musicrecognizer.track_metadata.title"
+    const val AUDILE_METADATA_KEY_TRACK_ARTIST = "com.mrsep.musicrecognizer.track_metadata.artist"
+    // TODO delete unused
+    const val AUDILE_METADATA_KEY_TRACK_ALBUM = "com.mrsep.musicrecognizer.track_metadata.album"
+    const val AUDILE_METADATA_KEY_TRACK_RELEASE_DATE = "com.mrsep.musicrecognizer.track_metadata.release_date"
+    const val AUDILE_METADATA_KEY_TRACK_DURATION = "com.mrsep.musicrecognizer.track_metadata.duration"
+    const val AUDILE_METADATA_KEY_TRACK_SAMPLE_TIMESTAMP = "com.mrsep.musicrecognizer.track_metadata.sample_timestamp"
+    const val AUDILE_METADATA_KEY_TRACK_PLAYBACK_OFFSET = "com.mrsep.musicrecognizer.track_metadata.playback_offset"
 
     //    const val NOTIFICATION_TAG_SHAZAM = "NOTIFICATION_SHAZAM_RESULTS" //"auto_shazam_v2"
     const val PACKAGE_PANDORA = "com.pandora.android"
@@ -177,6 +184,12 @@ object Stuff {
     const val CHANNEL_NOTI_PERSISTENT = "noti_persistent"
     const val CHANNEL_NOTI_UPDATER = "noti_updater"
     const val CHANNEL_TEST_SCROBBLE_FROM_NOTI = "test_scrobble_from_noti"
+
+    val CHANNELS_AUDILE = setOf(
+        "com.mrsep.musicrecognizer.result",
+        "com.mrsep.musicrecognizer.foreground_result",
+        "com.mrsep.musicrecognizer.enqueued_result",
+    )
 
     val IGNORE_ARTIST_META_WITHOUT_FALLBACK = setOf(
         "com.google.android.youtube",


### PR DESCRIPTION
The current implementation in Pano Scrobbler has several issues:

1 - It scrobbles all notifications from Audile's recognition channel including errors and 'no-matches' notifications.
2 - It ignores deferred recognition (created in offline-mode) results, and simply adding this channel won't work due to different notification formatting.
3 - It mishandles timestamps for deferred recognitions. Example: If a user tried to recognize a song today but Audile sends the result tomorrow (due to no internet), I guess, the track should be scrobbled with yesterday's date (when it actually played).

Proposed fixes:
For issues 1 and 2: I can add track metadata in notification extras at [Audile level](https://github.com/aleksey-saenko/MusicRecognizer/compare/master...notification-track-extras), which avoids parsing different notification formats.
For 3: I can also add the listening date (sample_timestamp) in the extras, but I'm unsure how to adapt this in PanoScrobbler, hopefully, you'll be able to handle this.
Durations in ms, dates in ISO-8601.

What do you think?